### PR TITLE
Correct markdown links + change to all in home

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -3,7 +3,7 @@
 Sor far, MINLPLibJuMP includes `16` libraries in `.jl` format converted from `.gms` format.
 Here is a simple chart showing the status of each instance libraries.
 
-| Lib Name   | Converted  | Unconverted | % |
+| Lib Name   | Converted  | All | % |
 |--------------------|--------|------|-------|
 | [PODLib](@ref)     | 82     | -    | -     |
 | [bcp](@ref)        | 143    | 327  | 43.7% |

--- a/docs/src/morg.md
+++ b/docs/src/morg.md
@@ -6,7 +6,7 @@ There are `64` instances listed here.
 `1` instances return error when loading.
 
 ## Source
-These instances are recorded in (MINLP Cyber-Infrastructure)[http://www.minlp.org/].
+These instances are recorded in [MINLP Cyber-Infrastructure](http://www.minlp.org/).
 
 ## Instance Stats
 | NAME | LT | SENSE | VARS | BINVARS | INTVARS | CONS | LINCONS | NLCONS | OTHERCONS |

--- a/docs/src/mpec.md
+++ b/docs/src/mpec.md
@@ -4,7 +4,7 @@
 Mathematical programs with complementarity constraints. There are in total `92` instances included here.
 
 ## Source
-These instances are recorded in (MPEC Library)[http://www.gamsworld.org/mpec/mpeclib.htm].
+These instances are recorded in [MPEC Library](http://www.gamsworld.org/mpec/mpeclib.htm).
 
 ## Instance Stats
 | NAME | LT | SENSE | VARS | BINVARS | INTVARS | CONS | LINCONS | NLCONS | OTHERCONS |

--- a/docs/src/poly.md
+++ b/docs/src/poly.md
@@ -6,7 +6,7 @@ There are in total `98` instances listed here.
 `5` instances return error during loading.
 
 ## Source
-There instances are repsorted in a paper: Reduced RLT representations for nonconvex polynomial programming problems. Here is the (paper link)[https://link.springer.com/article/10.1007%2Fs10898-011-9757-3?LI=true].
+There instances are repsorted in a paper: Reduced RLT representations for nonconvex polynomial programming problems. Here is the [paper link](https://link.springer.com/article/10.1007%2Fs10898-011-9757-3?LI=true).
 
 ## Instance Stats
 | NAME | LT | SENSE | VARS | BINVARS | INTVARS | CONS | LINCONS | NLCONS | OTHERCONS |

--- a/docs/src/prince.md
+++ b/docs/src/prince.md
@@ -6,7 +6,7 @@ There are in total `889` instances.
 `20` instances returns error when loading.
 
 ## Source
-These instances are recorded in (PrincetonLib)[http://www.gamsworld.org/performance/princetonlib/princetonlib.htm]
+These instances are recorded in [PrincetonLib](http://www.gamsworld.org/performance/princetonlib/princetonlib.htm)
 
 ## Instance Stats
 | NAME | LT | SENSE | VARS | BINVARS | INTVARS | CONS | LINCONS | NLCONS | OTHERCONS |

--- a/docs/src/qcqp.md
+++ b/docs/src/qcqp.md
@@ -5,7 +5,7 @@ Quadratically constrained quadratic programs. There are in total `135` instances
 `9` instances returns error during loading.
 
 ## Source
-These instances are recorded in a paper: Bao, X., N. V. Sahinidis and M. Tawarmalani, Semidefinite relaxations for quadratically constrained quadratic programming: A review and comparisons, Mathematical Programming, 129:129-157, 2011. Here is the (paper link)[https://link.springer.com/article/10.1007%2Fs10107-011-0462-2?LI=true].
+These instances are recorded in a paper: Bao, X., N. V. Sahinidis and M. Tawarmalani, Semidefinite relaxations for quadratically constrained quadratic programming: A review and comparisons, Mathematical Programming, 129:129-157, 2011. Here is the [paper link](https://link.springer.com/article/10.1007%2Fs10107-011-0462-2?LI=true).
 
 ## Instance Stats
 | NAME | LT | SENSE | VARS | BINVARS | INTVARS | CONS | LINCONS | NLCONS | OTHERCONS |

--- a/docs/src/qcqp2.md
+++ b/docs/src/qcqp2.md
@@ -5,7 +5,7 @@ Quadratically constrained quadratic programs. There are in total `700` instances
 `71` instances returns error during loading.
 
 ## Source
-These instances are recorded in a paper: Bao, X., N. V. Sahinidis and M. Tawarmalani, Semidefinite relaxations for quadratically constrained quadratic programming: A review and comparisons, Mathematical Programming, 129:129-157, 2011. Here is the (paper link)[https://link.springer.com/article/10.1007%2Fs10107-011-0462-2?LI=true].
+These instances are recorded in a paper: Bao, X., N. V. Sahinidis and M. Tawarmalani, Semidefinite relaxations for quadratically constrained quadratic programming: A review and comparisons, Mathematical Programming, 129:129-157, 2011. Here is the [paper link](https://link.springer.com/article/10.1007%2Fs10107-011-0462-2?LI=true).
 
 
 ## Instance Stats

--- a/docs/src/qcqp3.md
+++ b/docs/src/qcqp3.md
@@ -5,7 +5,7 @@ Quadratically constrained quadratic programs. There are in total `320` instances
 `5` instances returns error during loading.
 
 ## Source
-These instances are recorded in a paper: Bao, X., N. V. Sahinidis and M. Tawarmalani, Semidefinite relaxations for quadratically constrained quadratic programming: A review and comparisons, Mathematical Programming, 129:129-157, 2011. Here is the (paper link)[https://link.springer.com/article/10.1007%2Fs10107-011-0462-2?LI=true].
+These instances are recorded in a paper: Bao, X., N. V. Sahinidis and M. Tawarmalani, Semidefinite relaxations for quadratically constrained quadratic programming: A review and comparisons, Mathematical Programming, 129:129-157, 2011. Here is the [paper link](https://link.springer.com/article/10.1007%2Fs10107-011-0462-2?LI=true).
 
 ## Instance Stats
 | NAME | LT | SENSE | VARS | BINVARS | INTVARS | CONS | LINCONS | NLCONS | OTHERCONS |


### PR DESCRIPTION
- Change of `unconverted` to `All` on home page
- Correct markdown links